### PR TITLE
Description for designation adapted

### DIFF
--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -406,6 +406,7 @@ components:
         designation:
           type: string
           maxLength: 140
+          description: This element shall always be populated with the account alias, if defined, otherwise with specific bank account name (e.g. bank saving account).
           example: Firmenkonto
         _links:
           type: object


### PR DESCRIPTION
A strong recommendation is added as description to the accountItem property designation. The property will remain optional.