### PR TITLE
Account type code added

### DIFF
--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -407,6 +407,45 @@ components:
           type: string
           maxLength: 140
           example: Firmenkonto
+        accountTypeCode:
+          type: string
+          description: |
+            Contains the account type code according to the ISO external cash account type code list. It is strongly recommended to use only the 5 codes below as follows:
+            
+            LOAN: Account used for loans (loan and mortgage accounts) - DE: Darlehenskonto, Kreditkonto, Baukreditkonto, Hypothekarkonto
+            
+            LLSV: Account used for savings with special interest and withdrawal terms (pension provision and vested benefits accounts) - DE: Vorsorge- und Freizügigkeitskonten
+            
+            SVGS - Account used for savings (all types of saving accounts)
+            
+            TRAN - Account used for transactions (all types of personal, current and payment accounts) - DE: Privat-, Kontokorent- und Zahlungsverkehrskonten
+            
+            OTHR - Account not otherwise specified (gathering pool for all other accounts)
+          example: TRAN
+          enum:
+            - CACC
+            - CARD 
+            - CASH
+            - CHAR
+            - CISH
+            - COMM
+            - CPAC
+            - LLSV
+            - LOAN
+            - MGLD
+            - MOMA
+            - NFCA
+            - NREX
+            - ODFT
+            - ONDP
+            - OTHR
+            - SACC
+            - SLRY
+            - SVGS
+            - TAXE
+            - TRAN
+            - TRAS
+            - VACC
         _links:
           type: object
           description: Contains the paths to additional resources for specific account (e.g. path to transactions resource).

--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -419,7 +419,7 @@ components:
           example: TRAN
           enum:
             - CACC
-            - CARD 
+            - CARD
             - CASH
             - CHAR
             - CISH

--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -411,16 +411,11 @@ components:
           type: string
           description: |
             Contains the account type code according to the ISO external cash account type code list. It is strongly recommended to use only the 5 codes below as follows:
-            
             LOAN: Account used for loans (loan and mortgage accounts) - DE: Darlehenskonto, Kreditkonto, Baukreditkonto, Hypothekarkonto
-            
             LLSV: Account used for savings with special interest and withdrawal terms (pension provision and vested benefits accounts) - DE: Vorsorge- und Freizügigkeitskonten
-            
-            SVGS - Account used for savings (all types of saving accounts)
-            
-            TRAN - Account used for transactions (all types of personal, current and payment accounts) - DE: Privat-, Kontokorent- und Zahlungsverkehrskonten
-            
-            OTHR - Account not otherwise specified (gathering pool for all other accounts)
+            SVGS: Account used for savings (all types of saving accounts)
+            TRAN: Account used for transactions (all types of personal, current and payment accounts) - DE: Privat-, Kontokorent- und Zahlungsverkehrskonten
+            OTHR: Account not otherwise specified (gathering pool for all other accounts)
           example: TRAN
           enum:
             - CACC


### PR DESCRIPTION
accountTypeCode is added as a new property to accountItem. The new property is optional.