### PR TITLE
AIS - Remove outer `transaction` array from response (issue #158)

### DIFF
--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -183,7 +183,7 @@ paths:
       summary: Retrieve transactions of a specific account
       externalDocs:
         description: Detailed factsheet for the `/transactions` endpoint.
-        url: https://github.com/sfti/xs2a-api/wiki/transactions-factsheet
+        url: https://github.com/swissfintechinnovations/ca-payment/wiki/Transaction-Endpoint-Factsheet
       description: |
         Returns the transaction list of the specified account.
         * When called without a date, it returns transactions for the current day. Both "pending" and "booked" entries may be included based

--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -182,7 +182,7 @@ paths:
         - accounts
       summary: Retrieve transactions of a specific account
       externalDocs:
-        description: Detailed factsheet for the `/transactions` endpoint.
+        description: A detailed description of how this endpoint is used is available in the wiki.
         url: https://github.com/swissfintechinnovations/ca-payment/wiki/Transaction-Endpoint-Factsheet
       description: |
         Returns the transaction list of the specified account.
@@ -213,9 +213,7 @@ paths:
         - $ref: '#/components/parameters/psu_user_agent'
       responses:
         '200':
-          description: |
-            Accepted - The request is valid, but the requested data is not yet available because the associated booking day is still
-            in progress or not finalized. The request can be repeated at a later time once the data has been finalized.
+          description: Transaction data of the specified account.
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/X-Correlation-ID'
@@ -226,6 +224,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/AccountTransactionReport'
         '202':
+          description: |
+            Accepted - The request is valid, but the requested data is not yet available because the associated booking day is still
+            in progress or not finalized. The request can be repeated at a later time once the data has been finalized.
           $ref: '#/components/responses/standard202'
         '204':
           description: |

--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -212,14 +212,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required:
-                  - transactions
-                properties:
-                  transactions:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/AccountTransactionReport'
+                $ref: '#/components/schemas/AccountTransactionReport'
         '202':
           $ref: '#/components/responses/standard202'
         '204':

--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -127,15 +127,12 @@ paths:
       description: |
         Returns account balance information of the specified account.
         * Returns the interim booked balance (ISO20022 Balance Type ITBD) for the current day, if called without a date. The balance is
-        calculated
-        in the course of the service provider's business day, at the time specified, and subject to further changes during the business day.
-        The
-        interim balance is calculated on the basis of booked credit and debit items during the calculation time/period specified.
+        calculated in the course of the service provider's business day, at the time specified, and subject to further changes during the
+        business day. The interim balance is calculated on the basis of booked credit and debit items during the calculation time/period
+        specified.
         * Returns the closing booked balance (ISO20022 Balance Type CLBD) for a specific day, if called for a past date. It is the sum of
-        the opening
-        booked balance at the beginning of that day and all entries booked to the account during that day. In case the specified day has not
-        yet been
-        finalized, the response code will be 202.
+        the opening booked balance at the beginning of that day and all entries booked to the account during that day. In case the specified
+        day has not yet been finalized, the response code will be 202.
       parameters:
         - $ref: '#/components/parameters/account_id'
         - $ref: '#/components/parameters/date'
@@ -184,27 +181,17 @@ paths:
       externalDocs:
         description: A detailed description of how this endpoint is used is available in the wiki.
         url: https://github.com/swissfintechinnovations/ca-payment/wiki/Transaction-Endpoint-Factsheet
-      description: >
+      description: |
         Returns the transaction list of the specified account.
-
-        * When called without a date, it returns all transactions since the last completed booking day. Both "pending" and "booked" entries may be
-        included based
-
-        on the entryStatus parameter.
-
+        * When called without a date, it returns all transactions since the last completed booking day. Both "pending" and "booked" entries
+        may be included based on the entryStatus parameter.
         * When called with a date range, only "booked" transactions from completed booking days are returned. For days not yet finalized, a
-
         202 response code is returned.
 
-
-        Results are sorted by bookingDate in descending order. Additional sorting logic is provider-specific but all providers must ensure stable and
-
-        consistent pagination behavior. If pagination is required, the server includes an opaque cursor in the `X-Next-Cursor` header. This cursor
-
-        identifies a specific position in the sorted result set and is internally derived from the sorting criteria.
-
+        Results are sorted by bookingDate in descending order. Additional sorting logic is provider-specific but all providers must ensure
+        stable and consistent pagination behavior. If pagination is required, the server includes an opaque cursor in the `X-Next-Cursor`
+        header. This cursor identifies a specific position in the sorted result set and is internally derived from the sorting criteria.
         Clients must pass this value unchanged in the `cursor` parameter of the next request to retrieve subsequent pages.
-
 
         Transaction details are optional in the schema, but all available information must be included if present for a given transaction.
       parameters:

--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -191,9 +191,9 @@ paths:
         * When called with a date range, only "booked" transactions from completed booking days are returned. For days not yet finalized, a
         202 response code is returned.
 
-        Results are sorted by bookingDate descending, then entryId descending. If pagination is required, the server includes a base64-encoded,
-        opaque cursor in the `X-Next-Cursor` header. This cursor identifies a specific position in the sorted result set and is internally derived
-        from this key combination.
+        Results are sorted by bookingDate in descending order. Additional sorting logic is provider-specific but all providers must ensure stable and
+        consistent pagination behavior. If pagination is required, the server includes an opaque cursor in the `X-Next-Cursor` header. This cursor
+        identifies a specific position in the sorted result set and is internally derived from the sorting criteria.
         Clients must pass this value unchanged in the `cursor` parameter of the next request to retrieve subsequent pages.
 
         Transaction details are optional in the schema, but all available information must be included if present for a given transaction.

--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -184,17 +184,27 @@ paths:
       externalDocs:
         description: A detailed description of how this endpoint is used is available in the wiki.
         url: https://github.com/swissfintechinnovations/ca-payment/wiki/Transaction-Endpoint-Factsheet
-      description: |
+      description: >
         Returns the transaction list of the specified account.
-        * When called without a date, it returns transactions for the current day. Both "pending" and "booked" entries may be included based
+
+        * When called without a date, it returns all transactions since the last completed booking day. Both "pending" and "booked" entries may be
+        included based
+
         on the entryStatus parameter.
+
         * When called with a date range, only "booked" transactions from completed booking days are returned. For days not yet finalized, a
+
         202 response code is returned.
 
+
         Results are sorted by bookingDate in descending order. Additional sorting logic is provider-specific but all providers must ensure stable and
+
         consistent pagination behavior. If pagination is required, the server includes an opaque cursor in the `X-Next-Cursor` header. This cursor
+
         identifies a specific position in the sorted result set and is internally derived from the sorting criteria.
+
         Clients must pass this value unchanged in the `cursor` parameter of the next request to retrieve subsequent pages.
+
 
         Transaction details are optional in the schema, but all available information must be included if present for a given transaction.
       parameters:

--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -228,12 +228,10 @@ paths:
         '202':
           $ref: '#/components/responses/standard202'
         '204':
-          description: >
+          description: |
             No Content - The request was successful, but no data is available for the requested date or parameters. No data is expected to become
-            available
-
-            in the future. This may occur if the requested period is outside the retention scope or if no entries exist for the given account and
-            criteria.
+            available in the future. This may occur if the requested period is outside the retention scope or if no entries exist for the given 
+            account and criteria.
           $ref: '#/components/responses/standard204'
         '400':
           $ref: '#/components/responses/standard400'

--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -182,7 +182,7 @@ paths:
         - accounts
       summary: Retrieve transactions of a specific account
       externalDocs:
-        description: Detailed factsheet for the `/transactions` endpoint
+        description: Detailed factsheet for the `/transactions` endpoint.
         url: https://github.com/sfti/xs2a-api/wiki/transactions-factsheet
       description: |
         Returns the transaction list of the specified account.

--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -230,7 +230,7 @@ paths:
         '204':
           description: |
             No Content - The request was successful, but no data is available for the requested date or parameters. No data is expected to become
-            available in the future. This may occur if the requested period is outside the retention scope or if no entries exist for the given 
+            available in the future. This may occur if the requested period is outside the retention scope or if no entries exist for the given
             account and criteria.
           $ref: '#/components/responses/standard204'
         '400':

--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -181,12 +181,22 @@ paths:
       tags:
         - accounts
       summary: Retrieve transactions of a specific account
+      externalDocs:
+        description: Detailed factsheet for the `/transactions` endpoint
+        url: https://github.com/sfti/xs2a-api/wiki/transactions-factsheet
       description: |
         Returns the transaction list of the specified account.
         * When called without a date, it returns transactions for the current day. Both "pending" and "booked" entries may be included based
         on the entryStatus parameter.
         * When called with a date range, only "booked" transactions from completed booking days are returned. For days not yet finalized, a
         202 response code is returned.
+
+        Results are sorted by bookingDate descending, then entryId descending. If pagination is required, the server includes a base64-encoded,
+        opaque cursor in the `X-Next-Cursor` header. This cursor identifies a specific position in the sorted result set and is internally derived
+        from this key combination.
+        Clients must pass this value unchanged in the `cursor` parameter of the next request to retrieve subsequent pages.
+
+        Transaction details are optional in the schema, but all available information must be included if present for a given transaction.
       parameters:
         - $ref: '#/components/parameters/account_id'
         - $ref: '#/components/parameters/date_from'
@@ -203,7 +213,9 @@ paths:
         - $ref: '#/components/parameters/psu_user_agent'
       responses:
         '200':
-          description: Account details of the requested account.
+          description: |
+            Accepted - The request is valid, but the requested data is not yet available because the associated booking day is still
+            in progress or not finalized. The request can be repeated at a later time once the data has been finalized.
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/X-Correlation-ID'
@@ -212,17 +224,16 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required:
-                  - transactions
-                properties:
-                  transactions:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/AccountTransactionReport'
+                $ref: '#/components/schemas/AccountTransactionReport'
         '202':
           $ref: '#/components/responses/standard202'
         '204':
+          description: >
+            No Content - The request was successful, but no data is available for the requested date or parameters. No data is expected to become
+            available
+
+            in the future. This may occur if the requested period is outside the retention scope or if no entries exist for the given account and
+            criteria.
           $ref: '#/components/responses/standard204'
         '400':
           $ref: '#/components/responses/standard400'

--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -181,12 +181,22 @@ paths:
       tags:
         - accounts
       summary: Retrieve transactions of a specific account
+      externalDocs:
+        description: Detailed factsheet for the `/transactions` endpoint
+        url: https://github.com/sfti/xs2a-api/wiki/transactions-factsheet
       description: |
         Returns the transaction list of the specified account.
         * When called without a date, it returns transactions for the current day. Both "pending" and "booked" entries may be included based
         on the entryStatus parameter.
         * When called with a date range, only "booked" transactions from completed booking days are returned. For days not yet finalized, a
         202 response code is returned.
+
+        Results are sorted by bookingDate descending, then entryId descending. If pagination is required, the server includes a base64-encoded,
+        opaque cursor in the `X-Next-Cursor` header. This cursor identifies a specific position in the sorted result set and is internally derived
+        from this key combination.
+        Clients must pass this value unchanged in the `cursor` parameter of the next request to retrieve subsequent pages.
+
+        Transaction details are optional in the schema, but all available information must be included if present for a given transaction.
       parameters:
         - $ref: '#/components/parameters/account_id'
         - $ref: '#/components/parameters/date_from'
@@ -1255,7 +1265,9 @@ components:
           $ref: '#/components/headers/Content-Language'
         X-Correlation-ID:
           $ref: '#/components/headers/X-Correlation-ID'
-      description: Accepted - Valid request, requested data not available yet. The request may be attempted at a later time.
+      description: |
+        Accepted – The request is valid, but the requested data is not yet available because the associated booking day is still
+        in progress or not finalized. The request can be repeated at a later time once the data has been finalized.
       content:
         application/json:
           schema:
@@ -1264,7 +1276,9 @@ components:
       headers:
         X-Correlation-ID:
           $ref: '#/components/headers/X-Correlation-ID'
-      description: No content - The server has successfully fulfilled the request. There is no content to return and never will be.
+      description: |
+        No Content – The request was successful, but no data is available for the requested date or parameters. No data is expected to become available
+        in the future. This may occur if the requested period is outside the retention scope or if no entries exist for the given account and criteria.
     standard400:
       headers:
         Content-Language:

--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -181,22 +181,12 @@ paths:
       tags:
         - accounts
       summary: Retrieve transactions of a specific account
-      externalDocs:
-        description: Detailed factsheet for the `/transactions` endpoint
-        url: https://github.com/sfti/xs2a-api/wiki/transactions-factsheet
       description: |
         Returns the transaction list of the specified account.
         * When called without a date, it returns transactions for the current day. Both "pending" and "booked" entries may be included based
         on the entryStatus parameter.
         * When called with a date range, only "booked" transactions from completed booking days are returned. For days not yet finalized, a
         202 response code is returned.
-
-        Results are sorted by bookingDate descending, then entryId descending. If pagination is required, the server includes a base64-encoded,
-        opaque cursor in the `X-Next-Cursor` header. This cursor identifies a specific position in the sorted result set and is internally derived
-        from this key combination.
-        Clients must pass this value unchanged in the `cursor` parameter of the next request to retrieve subsequent pages.
-
-        Transaction details are optional in the schema, but all available information must be included if present for a given transaction.
       parameters:
         - $ref: '#/components/parameters/account_id'
         - $ref: '#/components/parameters/date_from'
@@ -222,7 +212,14 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AccountTransactionReport'
+                type: object
+                required:
+                  - transactions
+                properties:
+                  transactions:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/AccountTransactionReport'
         '202':
           $ref: '#/components/responses/standard202'
         '204':
@@ -1265,9 +1262,7 @@ components:
           $ref: '#/components/headers/Content-Language'
         X-Correlation-ID:
           $ref: '#/components/headers/X-Correlation-ID'
-      description: |
-        Accepted – The request is valid, but the requested data is not yet available because the associated booking day is still
-        in progress or not finalized. The request can be repeated at a later time once the data has been finalized.
+      description: Accepted - Valid request, requested data not available yet. The request may be attempted at a later time.
       content:
         application/json:
           schema:
@@ -1276,9 +1271,7 @@ components:
       headers:
         X-Correlation-ID:
           $ref: '#/components/headers/X-Correlation-ID'
-      description: |
-        No Content – The request was successful, but no data is available for the requested date or parameters. No data is expected to become available
-        in the future. This may occur if the requested period is outside the retention scope or if no entries exist for the given account and criteria.
+      description: No content - The server has successfully fulfilled the request. There is no content to return and never will be.
     standard400:
       headers:
         Content-Language:

--- a/src/accountAPI.yaml
+++ b/src/accountAPI.yaml
@@ -186,7 +186,7 @@ paths:
         url: https://github.com/swissfintechinnovations/ca-payment/wiki/Transaction-Endpoint-Factsheet
       description: |
         Returns the transaction list of the specified account.
-        * When called without a date, it returns transactions for the current day. Both "pending" and "booked" entries may be included based
+        * When called without a date, it returns all transactions since the last completed booking day. Both "pending" and "booked" entries may be included based
         on the entryStatus parameter.
         * When called with a date range, only "booked" transactions from completed booking days are returned. For days not yet finalized, a
         202 response code is returned.

--- a/src/accountAPI.yaml
+++ b/src/accountAPI.yaml
@@ -183,7 +183,7 @@ paths:
       summary: Retrieve transactions of a specific account
       externalDocs:
         description: Detailed factsheet for the `/transactions` endpoint.
-        url: https://github.com/sfti/xs2a-api/wiki/transactions-factsheet
+        url: https://github.com/swissfintechinnovations/ca-payment/wiki/Transaction-Endpoint-Factsheet
       description: |
         Returns the transaction list of the specified account.
         * When called without a date, it returns transactions for the current day. Both "pending" and "booked" entries may be included based

--- a/src/accountAPI.yaml
+++ b/src/accountAPI.yaml
@@ -127,15 +127,12 @@ paths:
       description: |
         Returns account balance information of the specified account.
         * Returns the interim booked balance (ISO20022 Balance Type ITBD) for the current day, if called without a date. The balance is
-        calculated
-        in the course of the service provider's business day, at the time specified, and subject to further changes during the business day.
-        The
-        interim balance is calculated on the basis of booked credit and debit items during the calculation time/period specified.
+        calculated in the course of the service provider's business day, at the time specified, and subject to further changes during the
+        business day. The interim balance is calculated on the basis of booked credit and debit items during the calculation time/period
+        specified.
         * Returns the closing booked balance (ISO20022 Balance Type CLBD) for a specific day, if called for a past date. It is the sum of
-        the opening
-        booked balance at the beginning of that day and all entries booked to the account during that day. In case the specified day has not
-        yet been
-        finalized, the response code will be 202.
+        the opening booked balance at the beginning of that day and all entries booked to the account during that day. In case the specified
+        day has not yet been finalized, the response code will be 202.
       parameters:
         - $ref: ./components/parameters/path/account_id.yaml
         - $ref: ./components/parameters/query/date.yaml
@@ -186,14 +183,14 @@ paths:
         url: https://github.com/swissfintechinnovations/ca-payment/wiki/Transaction-Endpoint-Factsheet
       description: |
         Returns the transaction list of the specified account.
-        * When called without a date, it returns all transactions since the last completed booking day. Both "pending" and "booked" entries may be included based
-        on the entryStatus parameter.
+        * When called without a date, it returns all transactions since the last completed booking day. Both "pending" and "booked" entries
+        may be included based on the entryStatus parameter.
         * When called with a date range, only "booked" transactions from completed booking days are returned. For days not yet finalized, a
         202 response code is returned.
 
-        Results are sorted by bookingDate in descending order. Additional sorting logic is provider-specific but all providers must ensure stable and
-        consistent pagination behavior. If pagination is required, the server includes an opaque cursor in the `X-Next-Cursor` header. This cursor
-        identifies a specific position in the sorted result set and is internally derived from the sorting criteria.
+        Results are sorted by bookingDate in descending order. Additional sorting logic is provider-specific but all providers must ensure
+        stable and consistent pagination behavior. If pagination is required, the server includes an opaque cursor in the `X-Next-Cursor`
+        header. This cursor identifies a specific position in the sorted result set and is internally derived from the sorting criteria.
         Clients must pass this value unchanged in the `cursor` parameter of the next request to retrieve subsequent pages.
 
         Transaction details are optional in the schema, but all available information must be included if present for a given transaction.

--- a/src/accountAPI.yaml
+++ b/src/accountAPI.yaml
@@ -191,9 +191,9 @@ paths:
         * When called with a date range, only "booked" transactions from completed booking days are returned. For days not yet finalized, a
         202 response code is returned.
 
-        Results are sorted by bookingDate descending, then entryId descending. If pagination is required, the server includes a base64-encoded,
-        opaque cursor in the `X-Next-Cursor` header. This cursor identifies a specific position in the sorted result set and is internally derived
-        from this key combination.
+        Results are sorted by bookingDate in descending order. Additional sorting logic is provider-specific but all providers must ensure stable and
+        consistent pagination behavior. If pagination is required, the server includes an opaque cursor in the `X-Next-Cursor` header. This cursor
+        identifies a specific position in the sorted result set and is internally derived from the sorting criteria.
         Clients must pass this value unchanged in the `cursor` parameter of the next request to retrieve subsequent pages.
 
         Transaction details are optional in the schema, but all available information must be included if present for a given transaction.

--- a/src/accountAPI.yaml
+++ b/src/accountAPI.yaml
@@ -229,8 +229,9 @@ paths:
           $ref: ./components/responses/standard202.yaml
         '204':
           description: |
-            No Content - The request was successful, but no data is available for the requested date or parameters. No data is expected to become available
-            in the future. This may occur if the requested period is outside the retention scope or if no entries exist for the given account and criteria.
+            No Content - The request was successful, but no data is available for the requested date or parameters. No data is expected to become
+            available in the future. This may occur if the requested period is outside the retention scope or if no entries exist for the given 
+            account and criteria.
           $ref: ./components/responses/standard204.yaml
         '400':
           $ref: ./components/responses/standard400.yaml

--- a/src/accountAPI.yaml
+++ b/src/accountAPI.yaml
@@ -182,7 +182,7 @@ paths:
         - accounts
       summary: Retrieve transactions of a specific account
       externalDocs:
-        description: Detailed factsheet for the `/transactions` endpoint
+        description: Detailed factsheet for the `/transactions` endpoint.
         url: https://github.com/sfti/xs2a-api/wiki/transactions-factsheet
       description: |
         Returns the transaction list of the specified account.

--- a/src/accountAPI.yaml
+++ b/src/accountAPI.yaml
@@ -230,7 +230,7 @@ paths:
         '204':
           description: |
             No Content - The request was successful, but no data is available for the requested date or parameters. No data is expected to become
-            available in the future. This may occur if the requested period is outside the retention scope or if no entries exist for the given 
+            available in the future. This may occur if the requested period is outside the retention scope or if no entries exist for the given
             account and criteria.
           $ref: ./components/responses/standard204.yaml
         '400':

--- a/src/accountAPI.yaml
+++ b/src/accountAPI.yaml
@@ -181,12 +181,22 @@ paths:
       tags:
         - accounts
       summary: Retrieve transactions of a specific account
+      externalDocs:
+        description: Detailed factsheet for the `/transactions` endpoint
+        url: https://github.com/sfti/xs2a-api/wiki/transactions-factsheet
       description: |
         Returns the transaction list of the specified account.
         * When called without a date, it returns transactions for the current day. Both "pending" and "booked" entries may be included based
         on the entryStatus parameter.
         * When called with a date range, only "booked" transactions from completed booking days are returned. For days not yet finalized, a
         202 response code is returned.
+
+        Results are sorted by bookingDate descending, then entryId descending. If pagination is required, the server includes a base64-encoded,
+        opaque cursor in the `X-Next-Cursor` header. This cursor identifies a specific position in the sorted result set and is internally derived
+        from this key combination.
+        Clients must pass this value unchanged in the `cursor` parameter of the next request to retrieve subsequent pages.
+
+        Transaction details are optional in the schema, but all available information must be included if present for a given transaction.
       parameters:
         - $ref: ./components/parameters/path/account_id.yaml
         - $ref: ./components/parameters/query/date_from.yaml
@@ -203,7 +213,9 @@ paths:
         - $ref: ./components/parameters/header/psu_user_agent.yaml
       responses:
         '200':
-          description: Account details of the requested account.
+          description: |
+            Accepted - The request is valid, but the requested data is not yet available because the associated booking day is still
+            in progress or not finalized. The request can be repeated at a later time once the data has been finalized.
           headers:
             X-Correlation-ID:
               $ref: ./components/headers/X-Correlation-ID.yaml
@@ -212,17 +224,13 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required:
-                  - transactions
-                properties:
-                  transactions:
-                    type: array
-                    items:
-                      $ref: ./components/schemas/ais/AccountTransactionReport.yaml
+                $ref: ./components/schemas/ais/AccountTransactionReport.yaml
         '202':
           $ref: ./components/responses/standard202.yaml
         '204':
+          description: |
+            No Content - The request was successful, but no data is available for the requested date or parameters. No data is expected to become available
+            in the future. This may occur if the requested period is outside the retention scope or if no entries exist for the given account and criteria.
           $ref: ./components/responses/standard204.yaml
         '400':
           $ref: ./components/responses/standard400.yaml

--- a/src/accountAPI.yaml
+++ b/src/accountAPI.yaml
@@ -182,7 +182,7 @@ paths:
         - accounts
       summary: Retrieve transactions of a specific account
       externalDocs:
-        description: Detailed factsheet for the `/transactions` endpoint.
+        description: A detailed description of how this endpoint is used is available in the wiki.
         url: https://github.com/swissfintechinnovations/ca-payment/wiki/Transaction-Endpoint-Factsheet
       description: |
         Returns the transaction list of the specified account.
@@ -213,9 +213,7 @@ paths:
         - $ref: ./components/parameters/header/psu_user_agent.yaml
       responses:
         '200':
-          description: |
-            Accepted - The request is valid, but the requested data is not yet available because the associated booking day is still
-            in progress or not finalized. The request can be repeated at a later time once the data has been finalized.
+          description: Transaction data of the specified account.
           headers:
             X-Correlation-ID:
               $ref: ./components/headers/X-Correlation-ID.yaml
@@ -226,6 +224,9 @@ paths:
               schema:
                 $ref: ./components/schemas/ais/AccountTransactionReport.yaml
         '202':
+          description: |
+            Accepted - The request is valid, but the requested data is not yet available because the associated booking day is still
+            in progress or not finalized. The request can be repeated at a later time once the data has been finalized.
           $ref: ./components/responses/standard202.yaml
         '204':
           description: |


### PR DESCRIPTION
- Removed outer transactions array from the response.
The response no longer wraps the report inside a { transactions: [...] } object.

- The endpoint now directly returns an AccountTransactionReport, which contains the list of transaction entries.

- Pagination now applies to the entries within the AccountTransactionReport, rather than to an outer list of reports.