### PR TITLE
AIS- Change schema balancecurrencyamount to support negative amounts (issue #160)

### DIFF
--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -1044,7 +1044,7 @@ components:
           pattern: ^-?[0-9]{1,12}([.][0-9]{1,5})?$
           maxLength: 18
           description: The amount of the requested account balance.
-          example: 10.25
+          example: '10.25'
         currency:
           $ref: '#/components/schemas/Currency'
           description: The ISO currency three-letter code in which the balance and the account are held.

--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -1040,8 +1040,11 @@ components:
         - currency
       properties:
         amount:
-          $ref: '#/components/schemas/Amount'
+          type: string
+          pattern: ^-?[0-9]{1,12}([.][0-9]{1,5})?$
+          maxLength: 18
           description: The amount of the requested account balance.
+          example: 10.25
         currency:
           $ref: '#/components/schemas/Currency'
           description: The ISO currency three-letter code in which the balance and the account are held.

--- a/src/components/schemas/ais/BalanceCurrencyAmount.yaml
+++ b/src/components/schemas/ais/BalanceCurrencyAmount.yaml
@@ -7,7 +7,7 @@ required:
 properties:
   amount:
     type: string
-    pattern: '-?[0-9]{1,12}([.][0-9]{1,5})?'
+    pattern: ^-?[0-9]{1,12}([.][0-9]{1,5})?$
     maxLength: 18
     description: The amount of the requested account balance.
     example: 10.25

--- a/src/components/schemas/ais/BalanceCurrencyAmount.yaml
+++ b/src/components/schemas/ais/BalanceCurrencyAmount.yaml
@@ -10,7 +10,7 @@ properties:
     pattern: ^-?[0-9]{1,12}([.][0-9]{1,5})?$
     maxLength: 18
     description: The amount of the requested account balance.
-    example: 10.25
+    example: '10.25'
   currency:
     $ref: ../generic/Currency.yaml
     description: The ISO currency three-letter code in which the balance and the account are held.

--- a/src/components/schemas/ais/BalanceCurrencyAmount.yaml
+++ b/src/components/schemas/ais/BalanceCurrencyAmount.yaml
@@ -6,8 +6,11 @@ required:
   - currency
 properties:
   amount:
-    $ref: ../generic/Amount.yaml
+    type: string
+    pattern: '-?[0-9]{1,12}([.][0-9]{1,5})?'
+    maxLength: 18
     description: The amount of the requested account balance.
+    example: 10.25
   currency:
     $ref: ../generic/Currency.yaml
     description: The ISO currency three-letter code in which the balance and the account are held.


### PR DESCRIPTION
Changed the shared Amount schema to support optional negative values
