### PR TITLE
AIS - Update descriptions with behavior for empty results in list endpoints (issue #176)

### DIFF
--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -32,12 +32,12 @@ paths:
       tags:
         - accounts
       summary: Retrieve list of authorized accounts
-      description: >
-        Returns a paginated list of all accounts accessible in the current authenticated and consented context. The response contains an `accounts` array; if no accounts
-        are available, the array is empty (for example: `{"accounts": []}`).
+      description: |
+        Returns a paginated list of all accounts accessible in the current authenticated and consented context. The response contains an `accounts` array;
+        if no accounts are available, the array is empty (for example: `{"accounts": []}`).
 
-        Pagination is controlled via the `cursor` and `limit` query parameters. If more accounts are available, the `X-Next-Cursor` response header provides the cursor
-        value for the next page.
+        Pagination is controlled via the `cursor` and `limit` query parameters.
+        If more accounts are available, the `X-Next-Cursor` response header provides the cursor value for the next page.
       parameters:
         - $ref: '#/components/parameters/cursor'
         - $ref: '#/components/parameters/limit'

--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -187,7 +187,7 @@ paths:
         description: A detailed description of how this endpoint is used is available in the wiki.
         url: https://github.com/swissfintechinnovations/ca-payment/wiki/Transaction-Endpoint-Factsheet
       description: |
-        Returns the transaction list of the specified account.
+        Returns a paginated list of transactions for the specified account.
         * When called without a date, it returns all transactions since the last completed booking day. Both "pending" and "booked" entries
         may be included based on the entryStatus parameter.
         * When called with a date range, only "booked" transactions from completed booking days are returned. For days not yet finalized, a
@@ -406,9 +406,12 @@ paths:
         - iso20022
       summary: Retrieve a list of resource links to account reports (camt.052)
       description: |
-        Get a list of resource links to available account reports (camt.052) generated since the last End-of-Day (EOD) processing.
+        Returns a paginated list of resource links to available account reports (camt.052) generated since the last End-of-Day (EOD) processing.
         Only intraday reports created after the most recent EOD cycle are included.
         If no reports are available since the last EOD, return an empty list: {"reports": []}.
+
+        Pagination is supported through the `cursor` and `limit` query parameters. When additional results are available,
+        the `X-Next-Cursor` response header contains the cursor value for the next page of results.
 
         The returned account reports must conform to the XML schema and implementation guidelines defined by Swiss Payment Standards.
       parameters:

--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -33,8 +33,8 @@ paths:
         - accounts
       summary: Retrieve list of authorized accounts
       description: |
-        Returns a paginated list of all accounts accessible in the current authenticated and consented context. The response contains an `accounts` array;
-        if no accounts are available, the array is empty (for example: `{"accounts": []}`).
+        Returns a paginated list of all accounts accessible in the current authenticated and consented context. 
+        The response contains an `accounts` array; if no accounts are available, the array is empty (for example: `{"accounts": []}`).
 
         Pagination is controlled via the `cursor` and `limit` query parameters.
         If more accounts are available, the `X-Next-Cursor` response header provides the cursor value for the next page.

--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -33,7 +33,7 @@ paths:
         - accounts
       summary: Retrieve list of authorized accounts
       description: |
-        Returns a paginated list of all accounts accessible in the current authenticated and consented context. 
+        Returns a paginated list of all accounts accessible in the current authenticated and consented context.
         The response contains an `accounts` array; if no accounts are available, the array is empty (for example: `{"accounts": []}`).
 
         Pagination is controlled via the `cursor` and `limit` query parameters.
@@ -303,7 +303,7 @@ paths:
       summary: Retrieve a list of resource links to account statements (camt.053)
       description: |
         Returns a paginated list of resource links to available account statements (camt.053) for all accounts covered by the authenticated
-        eBanking contract. The referenced account statements comply with the XML schema and implementation guidelines defined by 
+        eBanking contract. The referenced account statements comply with the XML schema and implementation guidelines defined by
         Swiss Payment Standards (SPS).
 
         If the requested period covers multiple days, a separate account statement is provided for each available day and account. If no statements

--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -32,8 +32,12 @@ paths:
       tags:
         - accounts
       summary: Retrieve list of authorized accounts
-      description: |
-        Return the list of all accounts accessible for the logged in user. If no accounts are available, return an empty list: {"accounts": []}.
+      description: >
+        Returns a paginated list of all accounts accessible in the current authenticated and consented context. The response contains an `accounts` array; if no accounts
+        are available, the array is empty (for example: `{"accounts": []}`).
+
+        Pagination is controlled via the `cursor` and `limit` query parameters. If more accounts are available, the `X-Next-Cursor` response header provides the cursor
+        value for the next page.
       parameters:
         - $ref: '#/components/parameters/cursor'
         - $ref: '#/components/parameters/limit'

--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -302,11 +302,15 @@ paths:
         - iso20022
       summary: Retrieve a list of resource links to account statements (camt.053)
       description: |
-        Get a list of resource links to available account statements (camt.053) for all accounts covered by the eBanking contract delivered.
-        If the call covers a period of several days, then an account statement is returned for each day and account, if available.
-        If no statements are available for the requested period, return an empty list: {"statements": []}.
+        Returns a paginated list of resource links to available account statements (camt.053) for all accounts covered by the authenticated
+        eBanking contract. The referenced account statements comply with the XML schema and implementation guidelines defined by 
+        Swiss Payment Standards (SPS).
 
-        The returned account statements must be conform to the XML schema and implementation guidelines defined by Swiss Payment Standards.
+        If the requested period covers multiple days, a separate account statement is provided for each available day and account. If no statements
+        are available for the requested period, an empty list is returned (`{"statements": []}`).
+
+        Pagination is supported through the `cursor` and `limit` query parameters. When additional results are available,
+        the `X-Next-Cursor` response header contains the cursor value for the next page of results.
       parameters:
         - $ref: '#/components/parameters/date_from'
         - $ref: '#/components/parameters/date_to'

--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -33,7 +33,7 @@ paths:
         - accounts
       summary: Get a list of all accounts
       description: |
-        Get a list of all accounts for the authenticated context. The response contains an `accounts` array; 
+        Get a list of all accounts for the authenticated context. The response contains an `accounts` array;
         if no accounts are available, the array is empty (for example: `{"accounts": []}`).
 
         Pagination is controlled via the `cursor` and `limit` query parameters.

--- a/accountAPI.yaml
+++ b/accountAPI.yaml
@@ -32,7 +32,8 @@ paths:
       tags:
         - accounts
       summary: Retrieve list of authorized accounts
-      description: Return the list of all accounts accessible for the logged in user.
+      description: |
+        Return the list of all accounts accessible for the logged in user. If no accounts are available, return an empty list: {"accounts": []}.
       parameters:
         - $ref: '#/components/parameters/cursor'
         - $ref: '#/components/parameters/limit'
@@ -188,6 +189,8 @@ paths:
         * When called with a date range, only "booked" transactions from completed booking days are returned. For days not yet finalized, a
         202 response code is returned.
 
+        If no transactions match the requested date range or intraday window, return an empty list: {"entries": []}.
+
         Results are sorted by bookingDate in descending order. Additional sorting logic is provider-specific but all providers must ensure
         stable and consistent pagination behavior. If pagination is required, the server includes an opaque cursor in the `X-Next-Cursor`
         header. This cursor identifies a specific position in the sorted result set and is internally derived from the sorting criteria.
@@ -296,8 +299,10 @@ paths:
       summary: Retrieve a list of resource links to account statements (camt.053)
       description: |
         Get a list of resource links to available account statements (camt.053) for all accounts covered by the eBanking contract delivered.
-        The returned account statements must be conform to the XML schema and implementation guidelines defined by Swiss Payment Standards.
         If the call covers a period of several days, then an account statement is returned for each day and account, if available.
+        If no statements are available for the requested period, return an empty list: {"statements": []}.
+
+        The returned account statements must be conform to the XML schema and implementation guidelines defined by Swiss Payment Standards.
       parameters:
         - $ref: '#/components/parameters/date_from'
         - $ref: '#/components/parameters/date_to'
@@ -395,6 +400,8 @@ paths:
       description: |
         Get a list of resource links to available account reports (camt.052) generated since the last End-of-Day (EOD) processing.
         Only intraday reports created after the most recent EOD cycle are included.
+        If no reports are available since the last EOD, return an empty list: {"reports": []}.
+
         The returned account reports must conform to the XML schema and implementation guidelines defined by Swiss Payment Standards.
       parameters:
         - $ref: '#/components/parameters/cursor'

--- a/src/accountAPI.yaml
+++ b/src/accountAPI.yaml
@@ -33,7 +33,8 @@ paths:
         - accounts
       summary: Retrieve list of authorized accounts
       description: |
-        Return the list of all accounts accessible for the logged in user. If no accounts are available, return an empty list: {"accounts": []}.
+        Returns a paginated list of all accounts accessible in the current authenticated and consented context. The response contains an `accounts` array; if no accounts are available, the array is empty (for example: `{"accounts": []}`).
+        Pagination is controlled via the `cursor` and `limit` query parameters. If more accounts are available, the `X-Next-Cursor` response header provides the cursor value for the next page.
       parameters:
         - $ref: ./components/parameters/query/cursor.yaml
         - $ref: ./components/parameters/query/limit.yaml

--- a/src/accountAPI.yaml
+++ b/src/accountAPI.yaml
@@ -187,7 +187,7 @@ paths:
         description: A detailed description of how this endpoint is used is available in the wiki.
         url: https://github.com/swissfintechinnovations/ca-payment/wiki/Transaction-Endpoint-Factsheet
       description: |
-        Returns the transaction list of the specified account.
+        Returns a paginated list of transactions for the specified account.
         * When called without a date, it returns all transactions since the last completed booking day. Both "pending" and "booked" entries
         may be included based on the entryStatus parameter.
         * When called with a date range, only "booked" transactions from completed booking days are returned. For days not yet finalized, a
@@ -406,9 +406,12 @@ paths:
         - iso20022
       summary: Retrieve a list of resource links to account reports (camt.052)
       description: |
-        Get a list of resource links to available account reports (camt.052) generated since the last End-of-Day (EOD) processing.
+        Returns a paginated list of resource links to available account reports (camt.052) generated since the last End-of-Day (EOD) processing.
         Only intraday reports created after the most recent EOD cycle are included.
         If no reports are available since the last EOD, return an empty list: {"reports": []}.
+
+        Pagination is supported through the `cursor` and `limit` query parameters. When additional results are available,
+        the `X-Next-Cursor` response header contains the cursor value for the next page of results.
 
         The returned account reports must conform to the XML schema and implementation guidelines defined by Swiss Payment Standards.
       parameters:

--- a/src/accountAPI.yaml
+++ b/src/accountAPI.yaml
@@ -33,8 +33,11 @@ paths:
         - accounts
       summary: Retrieve list of authorized accounts
       description: |
-        Returns a paginated list of all accounts accessible in the current authenticated and consented context. The response contains an `accounts` array; if no accounts are available, the array is empty (for example: `{"accounts": []}`).
-        Pagination is controlled via the `cursor` and `limit` query parameters. If more accounts are available, the `X-Next-Cursor` response header provides the cursor value for the next page.
+        Returns a paginated list of all accounts accessible in the current authenticated and consented context. The response contains an `accounts` array;
+        if no accounts are available, the array is empty (for example: `{"accounts": []}`).
+        
+        Pagination is controlled via the `cursor` and `limit` query parameters.
+        If more accounts are available, the `X-Next-Cursor` response header provides the cursor value for the next page.
       parameters:
         - $ref: ./components/parameters/query/cursor.yaml
         - $ref: ./components/parameters/query/limit.yaml

--- a/src/accountAPI.yaml
+++ b/src/accountAPI.yaml
@@ -33,7 +33,7 @@ paths:
         - accounts
       summary: Retrieve list of authorized accounts
       description: |
-        Returns a paginated list of all accounts accessible in the current authenticated and consented context. 
+        Returns a paginated list of all accounts accessible in the current authenticated and consented context.
         The response contains an `accounts` array; if no accounts are available, the array is empty (for example: `{"accounts": []}`).
 
         Pagination is controlled via the `cursor` and `limit` query parameters.
@@ -303,7 +303,7 @@ paths:
       summary: Retrieve a list of resource links to account statements (camt.053)
       description: |
         Returns a paginated list of resource links to available account statements (camt.053) for all accounts covered by the authenticated
-        eBanking contract. The referenced account statements comply with the XML schema and implementation guidelines defined by 
+        eBanking contract. The referenced account statements comply with the XML schema and implementation guidelines defined by
         Swiss Payment Standards (SPS).
 
         If the requested period covers multiple days, a separate account statement is provided for each available day and account. If no statements

--- a/src/accountAPI.yaml
+++ b/src/accountAPI.yaml
@@ -188,7 +188,7 @@ paths:
         may be included based on the entryStatus parameter.
         * When called with a date range, only "booked" transactions from completed booking days are returned. For days not yet finalized, a
         202 response code is returned.
-        
+
         If no transactions match the requested date range or intraday window, return an empty list: {"entries": []}.
 
         Results are sorted by bookingDate in descending order. Additional sorting logic is provider-specific but all providers must ensure
@@ -301,7 +301,7 @@ paths:
         Get a list of resource links to available account statements (camt.053) for all accounts covered by the eBanking contract delivered.
         If the call covers a period of several days, then an account statement is returned for each day and account, if available.
         If no statements are available for the requested period, return an empty list: {"statements": []}.
-        
+
         The returned account statements must be conform to the XML schema and implementation guidelines defined by Swiss Payment Standards.
       parameters:
         - $ref: ./components/parameters/query/date_from.yaml
@@ -401,7 +401,7 @@ paths:
         Get a list of resource links to available account reports (camt.052) generated since the last End-of-Day (EOD) processing.
         Only intraday reports created after the most recent EOD cycle are included.
         If no reports are available since the last EOD, return an empty list: {"reports": []}.
-        
+
         The returned account reports must conform to the XML schema and implementation guidelines defined by Swiss Payment Standards.
       parameters:
         - $ref: ./components/parameters/query/cursor.yaml

--- a/src/accountAPI.yaml
+++ b/src/accountAPI.yaml
@@ -32,7 +32,8 @@ paths:
       tags:
         - accounts
       summary: Retrieve list of authorized accounts
-      description: Return the list of all accounts accessible for the logged in user.
+      description: |
+        Return the list of all accounts accessible for the logged in user. If no accounts are available, return an empty list: {"accounts": []}.
       parameters:
         - $ref: ./components/parameters/query/cursor.yaml
         - $ref: ./components/parameters/query/limit.yaml
@@ -187,6 +188,8 @@ paths:
         may be included based on the entryStatus parameter.
         * When called with a date range, only "booked" transactions from completed booking days are returned. For days not yet finalized, a
         202 response code is returned.
+        
+        If no transactions match the requested date range or intraday window, return an empty list: {"entries": []}.
 
         Results are sorted by bookingDate in descending order. Additional sorting logic is provider-specific but all providers must ensure
         stable and consistent pagination behavior. If pagination is required, the server includes an opaque cursor in the `X-Next-Cursor`
@@ -296,8 +299,10 @@ paths:
       summary: Retrieve a list of resource links to account statements (camt.053)
       description: |
         Get a list of resource links to available account statements (camt.053) for all accounts covered by the eBanking contract delivered.
-        The returned account statements must be conform to the XML schema and implementation guidelines defined by Swiss Payment Standards.
         If the call covers a period of several days, then an account statement is returned for each day and account, if available.
+        If no statements are available for the requested period, return an empty list: {"statements": []}.
+        
+        The returned account statements must be conform to the XML schema and implementation guidelines defined by Swiss Payment Standards.
       parameters:
         - $ref: ./components/parameters/query/date_from.yaml
         - $ref: ./components/parameters/query/date_to.yaml
@@ -395,6 +400,8 @@ paths:
       description: |
         Get a list of resource links to available account reports (camt.052) generated since the last End-of-Day (EOD) processing.
         Only intraday reports created after the most recent EOD cycle are included.
+        If no reports are available since the last EOD, return an empty list: {"reports": []}.
+        
         The returned account reports must conform to the XML schema and implementation guidelines defined by Swiss Payment Standards.
       parameters:
         - $ref: ./components/parameters/query/cursor.yaml

--- a/src/accountAPI.yaml
+++ b/src/accountAPI.yaml
@@ -302,11 +302,15 @@ paths:
         - iso20022
       summary: Retrieve a list of resource links to account statements (camt.053)
       description: |
-        Get a list of resource links to available account statements (camt.053) for all accounts covered by the eBanking contract delivered.
-        If the call covers a period of several days, then an account statement is returned for each day and account, if available.
-        If no statements are available for the requested period, return an empty list: {"statements": []}.
+        Returns a paginated list of resource links to available account statements (camt.053) for all accounts covered by the authenticated
+        eBanking contract. The referenced account statements comply with the XML schema and implementation guidelines defined by 
+        Swiss Payment Standards (SPS).
 
-        The returned account statements must be conform to the XML schema and implementation guidelines defined by Swiss Payment Standards.
+        If the requested period covers multiple days, a separate account statement is provided for each available day and account. If no statements
+        are available for the requested period, an empty list is returned (`{"statements": []}`).
+
+        Pagination is supported through the `cursor` and `limit` query parameters. When additional results are available,
+        the `X-Next-Cursor` response header contains the cursor value for the next page of results.
       parameters:
         - $ref: ./components/parameters/query/date_from.yaml
         - $ref: ./components/parameters/query/date_to.yaml

--- a/src/accountAPI.yaml
+++ b/src/accountAPI.yaml
@@ -33,9 +33,9 @@ paths:
         - accounts
       summary: Retrieve list of authorized accounts
       description: |
-        Returns a paginated list of all accounts accessible in the current authenticated and consented context. The response contains an `accounts` array;
-        if no accounts are available, the array is empty (for example: `{"accounts": []}`).
-        
+        Returns a paginated list of all accounts accessible in the current authenticated and consented context. 
+        The response contains an `accounts` array; if no accounts are available, the array is empty (for example: `{"accounts": []}`).
+
         Pagination is controlled via the `cursor` and `limit` query parameters.
         If more accounts are available, the `X-Next-Cursor` response header provides the cursor value for the next page.
       parameters:

--- a/src/accountAPI.yaml
+++ b/src/accountAPI.yaml
@@ -33,7 +33,7 @@ paths:
         - accounts
       summary: Get a list of all accounts
       description: |
-        Get a list of all accounts for the authenticated context. The response contains an `accounts` array; 
+        Get a list of all accounts for the authenticated context. The response contains an `accounts` array;
         if no accounts are available, the array is empty (for example: `{"accounts": []}`).
 
         Pagination is controlled via the `cursor` and `limit` query parameters.


### PR DESCRIPTION
Descriptions of all Endpoints with lists adjusted according to Option 1 in GitHub Issue:

Option 1 — Add a sentence + empty example on each endpoint

/accounts: “Returns the list of all accounts accessible for the logged-in user. If no accounts are available, return an empty list: { "accounts": [] }.”
/accounts/{accountId}/transactions: “Returns the transaction list of the specified account. If no transactions match the requested date range or intraday window, return an empty list: { "entries": [] }.”
/iso20022/statements: “Get a list of resource links to available account statements (camt.053)… If no statements are available for the requested period, return an empty list: { "statements": [] }.”
/iso20022/reports: “Get a list of resource links to available account reports (camt.052) generated since the last EOD… If no reports are available since the last EOD, return an empty list: { "reports": [] }.”